### PR TITLE
fix: reg element display in examples

### DIFF
--- a/server/curfu/routers/demo.py
+++ b/server/curfu/routers/demo.py
@@ -5,6 +5,7 @@ from typing import Union
 from fastapi import APIRouter, Request
 from fusor import examples, FUSOR
 from fusor.models import (
+    RegulatoryElement,
     StructuralElementType,
     CategoricalFusion,
     AssayedFusion,
@@ -14,6 +15,7 @@ from fusor.nomenclature import (
     tx_segment_nomenclature,
     templated_seq_nomenclature,
     gene_nomenclature,
+    reg_element_nomenclature,
 )
 
 from curfu.schemas import (
@@ -127,6 +129,19 @@ def clientify_fusion(fusion: Fusion, fusor_instance: FUSOR) -> ClientFusion:
             clientify_structural_element(element, fusor_instance, i == 0, i == last)
         )
     fusion_args["structural_elements"] = client_elements
+
+    if "regulatory_element" in fusion_args and fusion_args["regulatory_element"]:
+        reg_element_args = fusion_args["regulatory_element"]
+        nomenclature = reg_element_nomenclature(
+            RegulatoryElement(**reg_element_args), fusor_instance.seqrepo
+        )
+        reg_element_args["nomenclature"] = nomenclature
+        regulatory_class = fusion_args["regulatory_element"]["regulatory_class"]
+        if regulatory_class == "enhancer":
+            reg_element_args["display_class"] = "Enhancer"
+        else:
+            raise Exception("Undefined reg element class used in demo")
+        fusion_args["regulatory_element"] = reg_element_args
 
     if fusion.type == FUSORTypes.CATEGORICAL_FUSION:
         if fusion.critical_functional_domains:

--- a/server/curfu/routers/nomenclature.py
+++ b/server/curfu/routers/nomenclature.py
@@ -70,9 +70,7 @@ def generate_regulatory_element_nomenclature(
     response_model=NomenclatureResponse,
     response_model_exclude_none=True,
 )
-def generate_tx_segment_nomenclature(
-    tx_segment: Dict = Body()
-) -> ResponseDict:
+def generate_tx_segment_nomenclature(tx_segment: Dict = Body()) -> ResponseDict:
     """
     Build transcript segment element nomenclature.
     :param request: the HTTP request context, supplied by FastAPI. Use to access

--- a/server/curfu/schemas.py
+++ b/server/curfu/schemas.py
@@ -267,6 +267,7 @@ class ClientCategoricalFusion(CategoricalFusion):
     global FusionContext.
     """
 
+    regulatory_element: Optional[ClientRegulatoryElement] = None
     structural_elements: List[
         Union[
             ClientTranscriptSegmentElement,
@@ -284,6 +285,7 @@ class ClientAssayedFusion(AssayedFusion):
     global FusionContext.
     """
 
+    regulatory_element: Optional[ClientRegulatoryElement] = None
     structural_elements: List[
         Union[
             ClientTranscriptSegmentElement,


### PR DESCRIPTION
Examples endpoints weren't propagating some fields that are required for user interface elements. Fixed.