### PR TITLE
cicd: get elastic beanstalk to deploy

### DIFF
--- a/.ebextensions/01_build.config
+++ b/.ebextensions/01_build.config
@@ -3,16 +3,13 @@ commands:
         command: "yum install -y python-devel postgresql-devel"
     02_eb_packages:
         command: "/var/app/venv/staging-LQM1lest/bin/pip install uvloop websockets httptools typing-extensions"
-    03_download_node:
-        test: test ! -f /usr/bin/node
-        command: "curl --silent --location https://deb.nodesource.com/setup_16.x | bash -"
-    04_install_node:
+    03_install_node:
         test: test ! -f /usr/bin/node
         command: "yum install -y nodejs"
-    05_download_yarn:
+    04_download_yarn:
         test: test ! -f /usr/bin/yarn
         command: "wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo"
-    06_install_yarn:
+    05_install_yarn:
         test: test ! -f /usr/bin/yarn
         command: "yum install -y yarn"
 

--- a/.ebextensions/02_data_downloads.config
+++ b/.ebextensions/02_data_downloads.config
@@ -19,7 +19,7 @@ container_commands:
 
     03_p7zip_seqrepo:
         test: test -f "/usr/local/share/seqrepo.zip"
-        command: "7za x /usr/local/share/seqrepo.zip -o /usr/local/share -y"
+        command: "7za x /usr/local/share/seqrepo.zip -o/usr/local/share -y"
 
     04_seqrepo_permission:
         test: test -d "/usr/local/share/seqrepo"


### PR DESCRIPTION
- I looked up if React needed node (since installation was the problem with deploying). This was the first response I saw:
  > Some people mistakenly assume that Node is required in order to use React. It is not. You don't need Node to run a React project. You don't even need a browser.

  So I went with it and tried removing the node command. Deployment succeeded (sc-292). The app seems to work (from what I can tell). If node is needed, this at least provides a temp fix to be able to deploy. Maybe try using `nvm` to install node if you do need it. 
- Fixes `03_p7zip_seqrepo` command. It was a typo. This is the command I used in variation-normalizer and metakb.  The previous solution gave this error:
  ```
  Command Line Error:
  Too short switch:
  -o
  ```
