### PR TITLE
docs: remove docstring types and clean up formatting

### DIFF
--- a/server/src/curfu/devtools/__init__.py
+++ b/server/src/curfu/devtools/__init__.py
@@ -8,9 +8,9 @@ from curfu import logger
 
 def ftp_download(domain: str, path: str, fname: str, callback: Callable) -> None:
     """Acquire file via FTP.
-    :param str domain: domain name for remote file host
-    :param str path: path within host to desired file
-    :param str fname: name of desired file as provided on host
+    :param domain: domain name for remote file host
+    :param path: path within host to desired file
+    :param fname: name of desired file as provided on host
     """
     try:
         with ftplib.FTP(domain) as ftp:

--- a/server/src/curfu/devtools/build_interpro.py
+++ b/server/src/curfu/devtools/build_interpro.py
@@ -27,7 +27,7 @@ DATE_FMT = "%Y%m%d"
 
 def download_protein2ipr(output_dir: Path) -> None:
     """Download, unpack, and store Uniprot-InterPro translation table
-    :param Path output_dir: location to save file within
+    :param output_dir: location to save file within
     """
     logger.info("Retrieving Uniprot mapping data from InterPro")
 
@@ -109,7 +109,7 @@ def get_uniprot_refs() -> UniprotRefs:
 
 def download_uniprot_sprot(output_dir: Path) -> Path:
     """Retrieve UniProtKB data.
-    :param Path output_dir: directory to save UniProtKB data in.
+    :param output_dir: directory to save UniProtKB data in.
     """
     logger.info("Retrieving UniProtKB data.")
 
@@ -144,10 +144,10 @@ def get_interpro_uniprot_rels(
     """Process InterPro to UniProtKB relations, using UniProt references to connect
     genes with domains
 
-    :param Optional[path] protein_ipr_path: path to protein2ipr_YYYYMMDD.dat if given
-    :param Path output_dir: Path to save output data in
-    :param Set[str] domain_ids: InterPro domain IDs to use
-    :param Dict uniprot_refs: UniProt references from gene normalizer DB
+    :param protein_ipr_path: path to protein2ipr_YYYYMMDD.dat if given
+    :param output_dir: Path to save output data in
+    :param domain_ids: InterPro domain IDs to use
+    :param uniprot_refs: UniProt references from gene normalizer DB
     :return: Dict mapping Uniprot accession ID to collected domain data,
     """
     if not protein_ipr_path:
@@ -191,9 +191,9 @@ def get_protein_accessions(
 ) -> dict[tuple[str, str], str]:
     """Scan uniprot_sprot.xml and extract RefSeq protein accession identifiers for
     relevant Uniprot accessions.
-    :param Set[str] relevant_proteins: captured Uniprot accessions, for proteins coded
+    :param relevant_proteins: captured Uniprot accessions, for proteins coded
         by human genes and containing InterPro functional domains
-    :param Optional[Path] uniprot_sprot_path: path to local uniprot_sprot.xml file.
+    :param uniprot_sprot_path: path to local uniprot_sprot.xml file.
     :return: Dict where keys are tuple containing Uniprot accession ID and NCBI gene ID,
         and values are known RefSeq protein accessions
     """
@@ -279,11 +279,11 @@ def build_gene_domain_maps(
     """Produce the gene-to-domain lookup table at out_path using the Interpro-Uniprot
     translation table, the Interpro names table, and the VICC Gene Normalizer.
 
-    :param Set[str] interpro_types: types of interpro fields to check references for
-    :param Path protein_ipr_path: path to protein2ipr_{date}.dat if available
-    :param Optional[Path] uniprot_refs_path: path to existing uniprot_refs_<date>.tsv
+    :param interpro_types: types of interpro fields to check references for
+    :param protein_ipr_path: path to protein2ipr_{date}.dat if available
+    :param uniprot_refs_path: path to existing uniprot_refs_<date>.tsv
         file if available.
-    :param Path output_dir: location to save output file within. Defaults to app data
+    :param output_dir: location to save output file within. Defaults to app data
         directory.
     """
     start_time = timer()

--- a/server/src/curfu/gene_services.py
+++ b/server/src/curfu/gene_services.py
@@ -52,10 +52,10 @@ class GeneService:
         term: str, normalizer: QueryHandler
     ) -> tuple[CURIE, str, str | CURIE | None]:
         """Get normalized ID given gene symbol/label/alias.
-        :param str term: user-entered gene term
-        :param QueryHandler normalizer:  gene normalizer instance
-        :returns: concept ID, str, if successful
-        :raises ServiceWarning: if lookup fails
+        :param term: user-entered gene term
+        :param normalizer:  gene normalizer instance
+        :return: concept ID, str, if successful
+        :raise ServiceWarning: if lookup fails
         """
         response = normalizer.normalize(term)
         if response.match_type != MatchType.NO_MATCH:
@@ -131,8 +131,8 @@ class GeneService:
     def suggest_genes(self, query: str) -> dict[str, list[Suggestion]]:
         """Provide autocomplete suggestions based on submitted term.
 
-        :param str query: text entered by user
-        :returns: dict returning list containing any number of suggestion tuples, where
+        :param query: text entered by user
+        :return: dict returning list containing any number of suggestion tuples, where
             each is the correctly-cased term, normalized ID, normalized label, for each
             item type
         """

--- a/server/src/curfu/routers/__init__.py
+++ b/server/src/curfu/routers/__init__.py
@@ -3,6 +3,7 @@
 
 def parse_identifier(identifier: str) -> str:
     """Restructure ID value to mesh with serverside requirements
+
     :param transcript: user-submitted accession identifier
     :return: reformatted to conform to UTA requirements
     """

--- a/server/src/curfu/routers/complete.py
+++ b/server/src/curfu/routers/complete.py
@@ -25,11 +25,11 @@ router = APIRouter()
 def suggest_gene(request: Request, term: str = Query("")) -> ResponseDict:
     """Provide completion suggestions for term provided by user.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
-        FUSOR and UTA-associated tools.
-    :param str term: entered gene term
-    :return: JSON response with suggestions listed, or warnings if unable to
-        provide suggestions.
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
+    :param term: entered gene term
+    :return: JSON response with suggestions listed, or warnings if unable to provide
+        suggestions.
     """
     response: ResponseDict = {"term": term}
     possible_matches = request.app.state.genes.suggest_genes(term)
@@ -64,9 +64,9 @@ def suggest_gene(request: Request, term: str = Query("")) -> ResponseDict:
 def suggest_domain(request: Request, gene_id: str = Query("")) -> ResponseDict:
     """Provide possible domains associated with a given gene to be selected by a user.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
-        FUSOR and UTA-associated tools.
-    :param str gene_id: normalized gene concept ID
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
+    :param gene_id: normalized gene concept ID
     :return: JSON response with a list of possible domain name and ID options, or
         warning(s) if relevant
     """

--- a/server/src/curfu/routers/demo.py
+++ b/server/src/curfu/routers/demo.py
@@ -164,7 +164,7 @@ def clientify_fusion(fusion: Fusion, fusor_instance: FUSOR) -> ClientFusion:
 def get_alk(request: Request) -> DemoResponse:
     """Retrieve ALK assayed fusion.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
+    :param request: the HTTP request context, supplied by FastAPI. Use to access
         FUSOR and UTA-associated tools.
     """
     return DemoResponse(
@@ -182,8 +182,8 @@ def get_alk(request: Request) -> DemoResponse:
 def get_ewsr1(request: Request) -> DemoResponse:
     """Retrieve EWSR1 assayed fusion.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
-        FUSOR and UTA-associated tools.
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
     """
     return DemoResponse(
         fusion=clientify_fusion(examples.ewsr1, request.app.state.fusor), warnings=[]
@@ -200,8 +200,8 @@ def get_ewsr1(request: Request) -> DemoResponse:
 def get_bcr_abl1(request: Request) -> DemoResponse:
     """Retrieve BCR-ABL1 categorical fusion.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
-        FUSOR and UTA-associated tools.
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
     """
     return DemoResponse(
         fusion=clientify_fusion(examples.bcr_abl1, request.app.state.fusor), warnings=[]
@@ -218,8 +218,8 @@ def get_bcr_abl1(request: Request) -> DemoResponse:
 def get_tpm3_ntrk1(request: Request) -> DemoResponse:
     """Retrieve TPM3-NTRK1 assayed fusion.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
-        FUSOR and UTA-associated tools.
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
     """
     return DemoResponse(
         fusion=clientify_fusion(examples.tpm3_ntrk1, request.app.state.fusor),
@@ -237,8 +237,8 @@ def get_tpm3_ntrk1(request: Request) -> DemoResponse:
 def get_tpm3_pdgfrb(request: Request) -> DemoResponse:
     """Retrieve TPM3-PDGFRB assayed fusion.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
-        FUSOR and UTA-associated tools.
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
     """
     return DemoResponse(
         fusion=clientify_fusion(examples.tpm3_pdgfrb, request.app.state.fusor),
@@ -255,8 +255,8 @@ def get_tpm3_pdgfrb(request: Request) -> DemoResponse:
 )
 def get_igh_myc(request: Request) -> DemoResponse:
     """Retrieve IGH-MYC assayed fusion.
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
-        FUSOR and UTA-associated tools.
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
     """
     return DemoResponse(
         fusion=clientify_fusion(examples.igh_myc, request.app.state.fusor), warnings=[]

--- a/server/src/curfu/routers/lookup.py
+++ b/server/src/curfu/routers/lookup.py
@@ -18,9 +18,9 @@ router = APIRouter()
 def normalize_gene(request: Request, term: str = Query("")) -> ResponseDict:
     """Normalize gene term provided by user.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
-        FUSOR and UTA-associated tools.
-    :param str term: gene symbol/alias/name/etc
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
+    :param term: gene symbol/alias/name/etc
     :return: JSON response with normalized ID if successful and warnings otherwise
     """
     response: ResponseDict = {"term": term}

--- a/server/src/curfu/routers/utilities.py
+++ b/server/src/curfu/routers/utilities.py
@@ -31,9 +31,9 @@ router = APIRouter()
 def get_mane_transcripts(request: Request, term: str) -> dict:
     """Get MANE transcripts for gene term.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
+    :param request: the HTTP request context, supplied by FastAPI. Use to access
         FUSOR and UTA-associated tools.
-    :param str term: gene term provided by user
+    :param term: gene term provided by user
     :return: Dict containing transcripts if lookup succeeds, or warnings upon failure
     """
     normalized = request.app.state.fusor.gene_normalizer.normalize(term)
@@ -68,14 +68,14 @@ async def get_genome_coords(
 ) -> CoordsUtilsResponse:
     """Convert provided exon positions to genomic coordinates
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
+    :param request: the HTTP request context, supplied by FastAPI. Use to access
         FUSOR and UTA-associated tools.
-    :param Optional[str] gene: gene symbol/ID on which exons lie
-    :param Optional[str] transcript: transcript accession ID
-    :param Optional[int] exon_start: starting exon number
-    :param Optional[int] exon_end: ending exon number
-    :param int exon_start_offset: base offset count from starting exon
-    :param int exon_end_offset: base offset count from end exon
+    :param gene: gene symbol/ID on which exons lie
+    :param transcript: transcript accession ID
+    :param exon_start: starting exon number
+    :param exon_end: ending exon number
+    :param exon_start_offset: base offset count from starting exon
+    :param exon_end_offset: base offset count from end exon
     :return: CoordsUtilsResponse containing relevant data or warnings if unsuccesful
     """
     warnings = []
@@ -143,14 +143,14 @@ async def get_exon_coords(
 ) -> CoordsUtilsResponse:
     """Convert provided genomic coordinates to exon coordinates
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use to access
-        FUSOR and UTA-associated tools.
-    :param str chromosome: chromosome, either as a number/X/Y or as an accession
-    :param Optional[int] start: genomic start position
-    :param Optional[int] end: genomic end position
-    :param Optional[str] strand: strand of genomic position
-    :param Optional[str] gene: gene symbol or ID
-    :param Optional[str] transcript: transcript accession ID
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
+    :param chromosome: chromosome, either as a number/X/Y or as an accession
+    :param start: genomic start position
+    :param end: genomic end position
+    :param strand: strand of genomic position
+    :param gene: gene symbol or ID
+    :param transcript: transcript accession ID
     :return: response with exon coordinates if successful, or warnings if failed
     """
     warnings: list[str] = []
@@ -195,9 +195,9 @@ async def get_exon_coords(
 async def get_sequence_id(request: Request, sequence: str) -> SequenceIDResponse:
     """Get GA4GH sequence ID and aliases given sequence sequence ID
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use
-        to access FUSOR and UTA-associated tools.
-    :param str sequence_id: user-provided sequence identifier to translate
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
+    :param sequence_id: user-provided sequence identifier to translate
     :return: Response object with ga4gh ID and aliases
     """
     params: dict[str, Any] = {"sequence": sequence, "ga4gh_id": None, "aliases": []}
@@ -251,8 +251,8 @@ async def get_sequence(
 ) -> FileResponse:
     """Get sequence for requested sequence ID.
     \f
-    :param Request request: the HTTP request context, supplied by FastAPI. Use
-        to access FUSOR and UTA-associated tools.
+    :param request: the HTTP request context, supplied by FastAPI. Use to access FUSOR
+        and UTA-associated tools.
     :param background_tasks: Starlette background tasks object. Use to clean up
         tempfile after get method returns.
     :param sequence_id: accession ID, sans namespace, eg `NM_152263.3`

--- a/server/src/curfu/sequence_services.py
+++ b/server/src/curfu/sequence_services.py
@@ -13,9 +13,9 @@ class InvalidInputError(Exception):
 def get_strand(strand_input: str) -> int:
     """Validate strand arguments received from client.
 
-    :param str input: strand argument from client
+    :param input: strand argument from client
     :return: correctly-formatted strand
-    :raises InvalidInputException: if strand arg is invalid
+    :raise InvalidInputException: if strand arg is invalid
     """
     if strand_input == "+":
         return 1


### PR DESCRIPTION
No functional changes, and it probably won't matter, but the extra type declarations were distracting me so I went through and pulled them all out