### PR TITLE
fix: handle unnecessary checks for build files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,6 @@ You can run:
 yarn install --ignore-engines
 ```
 
-Next, run the following commands:
-
-```
-yarn build
-mv build/ ../server/curfu/build
-```
-
 Then start the development server:
 
 ```commandline


### PR DESCRIPTION
Does a few things

* @korikuzma noticed that the README description of copying build files had an incorrect path. However, this instruction is actually unnecessary (and impractical tbh). In development you'd be better off letting `yarn start` handle service of client files because it has hot-reloading on changes. I removed it.
* Rather than requiring client files to be present, catches + logs their absence if they're not there. This is better for development. Originally I added this code in the big VRS update PR but it should've been a separate issue. I would like to see us reexamine our logging initialization/setup in another issue, because it could be bad if it's not working properly. 
* Adds some additional description of why the client service code is there + what it needs.